### PR TITLE
Use h5pyd if endpoint keyword is supplied

### DIFF
--- a/h5py_switch/__init__.py
+++ b/h5py_switch/__init__.py
@@ -16,7 +16,7 @@ else:
 def File(path, mode='a', **kwargs):
     """Either h5py.File or h5pyd.File depending on path."""
     if isinstance(path, str):
-        if path.startswith(('http://', 'https://', 'hdf5://')) or kwargs['endpoint']:
+        if path.startswith(('http://', 'https://', 'hdf5://')) or 'endpoint' in kwargs:
             if no_h5pyd:
                 raise ImportError(
                     'h5pyd package is required for: {}'.format(path))

--- a/h5py_switch/__init__.py
+++ b/h5py_switch/__init__.py
@@ -16,7 +16,7 @@ else:
 def File(path, mode='a', **kwargs):
     """Either h5py.File or h5pyd.File depending on path."""
     if isinstance(path, str):
-        if path.startswith(('http://', 'https://', 'hdf5://')):
+        if path.startswith(('http://', 'https://', 'hdf5://')) or kwargs['endpoint']:
             if no_h5pyd:
                 raise ImportError(
                     'h5pyd package is required for: {}'.format(path))


### PR DESCRIPTION
There are  a few situations where the filename will not be structured as an URL, but will use the `endpoint` keyword to make the connection to `h5serv`. This just allows either way to switch to `h5pyd`. 